### PR TITLE
Initial Laydown of color customization through config file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import shutil
 import sys
@@ -35,3 +36,6 @@ setup(
     },
     zip_safe=True
 )
+
+print("If you installed with sudo privileges, current owner of ~/.yolog directory "
+      "would be root. Please change the owner to user for better experience. ")

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 from setuptools import setup
+from ConfigParser import SafeConfigParser
 
 config_dirpath = os.path.expandvars(os.path.expanduser("~/.yolog"))
 
@@ -10,6 +11,15 @@ if os.path.exists(config_dirpath):
 
 if sys.argv[1] in {"build", "install", "develop"}:
     os.mkdir(config_dirpath)
+    config = SafeConfigParser()
+    config.add_section('color')
+    config.set('color', 'hash', 'YELLOW')
+    config.set('color', 'author', 'BLUE')
+    config.set('color', 'date', 'GREEN')
+    config.set('color', 'refs', 'RED')
+    config.set('color', 'description', 'WHITE')
+    with open(os.path.join(config_dirpath, 'config.ini'), 'w') as f:
+        config.write(f)
 
 setup(
     name='yolog',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,15 @@
+import os
+import shutil
+import sys
 from setuptools import setup
+
+config_dirpath = os.path.expandvars(os.path.expanduser("~/.yolog"))
+
+if os.path.exists(config_dirpath):
+    shutil.rmtree(config_dirpath)
+
+if sys.argv[1] in {"build", "install", "develop"}:
+    os.mkdir(config_dirpath)
 
 setup(
     name='yolog',

--- a/yolog/config_handler.py
+++ b/yolog/config_handler.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 from ConfigParser import SafeConfigParser
 import os
-import sys
 
 
 class ConfigHandler(object):
@@ -13,10 +12,11 @@ class ConfigHandler(object):
     def set_color(self, attribute, color):
         if attribute not in {"author", "date", "description", "hash", "refs"}:
             print("{0}: Invalid attribute !".format(attribute))
-        elif color not in {"WHITE", "BLACK", "RED", "GREEN", "CYAN", "BLUE", "PURPLE", "YELLOW"}:
+        elif color.upper() not in {"WHITE", "BLACK", "RED", "GREEN",
+                           "CYAN", "BLUE", "PURPLE", "YELLOW"}:
             print("{0}: Invalid color !".format(color))
         else:
-            self.config.set("color", attribute, color)
+            self.config.set("color", attribute, color.upper())
             with open(self.path, 'w') as f:
                 self.config.write(f)
             print("Changed Successfully !")

--- a/yolog/config_handler.py
+++ b/yolog/config_handler.py
@@ -10,13 +10,13 @@ class ConfigHandler(object):
         self.config = SafeConfigParser()
         self.config.read(self.path)
 
-    def set_color(attribute, color):
+    def set_color(self, attribute, color):
         if attribute not in {"author", "date", "description", "hash", "refs"}:
             print("{0}: Invalid attribute !".format(attribute))
         elif color not in {"WHITE", "BLACK", "RED", "GREEN", "CYAN", "BLUE", "PURPLE"}:
             print("{0}: Invalid color !".format(color))
         else:
             self.config.set("color", attribute, color)
-            with open(path, 'w') as f:
+            with open(self.path, 'w') as f:
                 self.config.write(f)
             print("Changed Successefully")

--- a/yolog/config_handler.py
+++ b/yolog/config_handler.py
@@ -1,0 +1,21 @@
+from ConfigParser import SafeConfigParser
+import os
+import sys
+
+
+class ConfigHandler(object):
+    def __init__(self, path):
+        self.path = os.path.expandvars(os.path.expanduser(path))
+        self.config = SafeConfigParser()
+        self.config.read(self.path)
+
+    def set_color(attribute, color):
+        if attribute not in {"author", "date", "description", "hash", "refs"}:
+            print("{0}: Invalid attribute !".format(attribute))
+        elif color not in {"WHITE", "BLACK", "RED", "GREEN", "CYAN", "BLUE", "PURPLE"}:
+            print("{0}: Invalid color !".format(color))
+        else:
+            self.config.set("color", attribute, color)
+            with open(path, 'w') as f:
+                self.config.write(f)
+            print("Changed Successefully")

--- a/yolog/config_handler.py
+++ b/yolog/config_handler.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from ConfigParser import SafeConfigParser
 import os
 import sys

--- a/yolog/config_handler.py
+++ b/yolog/config_handler.py
@@ -13,10 +13,10 @@ class ConfigHandler(object):
     def set_color(self, attribute, color):
         if attribute not in {"author", "date", "description", "hash", "refs"}:
             print("{0}: Invalid attribute !".format(attribute))
-        elif color not in {"WHITE", "BLACK", "RED", "GREEN", "CYAN", "BLUE", "PURPLE"}:
+        elif color not in {"WHITE", "BLACK", "RED", "GREEN", "CYAN", "BLUE", "PURPLE", "YELLOW"}:
             print("{0}: Invalid color !".format(color))
         else:
             self.config.set("color", attribute, color)
             with open(self.path, 'w') as f:
                 self.config.write(f)
-            print("Changed Successefully")
+            print("Changed Successfully !")

--- a/yolog/main.py
+++ b/yolog/main.py
@@ -48,6 +48,9 @@ def main():
         elif sys.argv[1] in {"-c", "--config", "config"}:
             config_handler = ConfigHandler("~/.yolog/config.ini")
             config_handler.set_color(sys.argv[2], sys.argv[3])
+        else:
+            yolog_gen = YologGenerator("~/.yolog/config.ini")
+            os.system(yolog_gen.git_command(" ".join(git_arguments)))
     else:
         yolog_gen = YologGenerator("~/.yolog/config.ini")
-        os.system(yolog_gen.git_command(" ".join(git_arguments)))
+        os.system(yolog_gen.git_command(" "))

--- a/yolog/main.py
+++ b/yolog/main.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import os
 import sys
 from yolog.yolog_generator import YologGenerator
+from yolog.config_handler import ConfigHandler
 
 yolog_gen = YologGenerator()
 
@@ -45,5 +46,7 @@ def main():
     git_arguments = sys.argv[1:]
     if git_arguments and (sys.argv[1] == "-h" or sys.argv[1] == "--help"):
         print(help_description)
+    elif git_arguments and (sys.argv[1] == "-config"):
+    	ConfigHandler()
     else:
         os.system(yolog_gen.git_command(" ".join(git_arguments)))

--- a/yolog/main.py
+++ b/yolog/main.py
@@ -4,8 +4,6 @@ import sys
 from yolog.yolog_generator import YologGenerator
 from yolog.config_handler import ConfigHandler
 
-yolog_gen = YologGenerator()
-
 help_description = ("""
 Yolog - Beautify your Git logs !
 --------------------------------
@@ -44,9 +42,12 @@ Usage: yolog [<additional optional commands>]
 
 def main():
     git_arguments = sys.argv[1:]
-    if git_arguments and (sys.argv[1] == "-h" or sys.argv[1] == "--help"):
-        print(help_description)
-    elif git_arguments and (sys.argv[1] == "-config"):
-    	ConfigHandler()
+    if git_arguments:
+        if sys.argv[1] in {"-h", "--help", "help"}:
+            print(help_description)
+        elif sys.argv[1] in {"-c", "--config", "config"}:
+            config_handler = ConfigHandler("~/.yolog/config.ini")
+            config_handler.set_color(sys.argv[2], sys.argv[3])
     else:
+        yolog_gen = YologGenerator("~/.yolog/config.ini")
         os.system(yolog_gen.git_command(" ".join(git_arguments)))

--- a/yolog/yolog_generator.py
+++ b/yolog/yolog_generator.py
@@ -1,3 +1,7 @@
+from ConfigParser import SafeConfigParser
+import os
+import sys
+
 RESET  = "$(tput sgr0)"
 BACKSPACE = "%x08"
 
@@ -12,16 +16,25 @@ class YologGenerator(object):
     CYAN   = "$(tput bold)$(tput setaf 6)"
     WHITE  = "$(tput setaf 7)"
 
-    def __init__(self):
-        self._hash = "{0}%h{1}".format(self.YELLOW, RESET)
+    def __init__(self, path):
+        self.config = SafeConfigParser()
+        self.path = os.path.expandvars(os.path.expanduser(path))
+        self.config.read(self.path)
 
-        self._author = "{0}%an{1}".format(self.BLUE, RESET)
+        self._hash = "{0}%h{1}".format(
+            getattr(self, self.config.get("color", "hash")), RESET)
 
-        self._date = "{0}%aD{1}{2}".format(self.GREEN, BACKSPACE * 15, RESET)
+        self._author = "{0}%an{1}".format(
+            getattr(self, self.config.get("color", "author")), RESET)
 
-        self._refs = "{0}%d{1}".format(self.RED, RESET)
+        self._date = "{0}%aD{1}{2}".format(
+            getattr(self, self.config.get("color", "date")), BACKSPACE * 15, RESET)
 
-        self._description = "{0}%s{1}".format(self.WHITE, RESET)
+        self._refs = "{0}%d{1}".format(
+            getattr(self, self.config.get("color", "refs")), RESET)
+
+        self._description = "{0}%s{1}".format(
+            getattr(self, self.config.get("color", "description")), RESET)
 
         self._format = "{0};;{1};;{2};;{3} {4}".format(
             self._hash, self._author, self._date, self._refs, self._description
@@ -33,4 +46,4 @@ class YologGenerator(object):
             "column -t -s \";;\" | less -FXRS".format(
                 self._format, git_arguments
             )
-        )
+        ) 

--- a/yolog/yolog_generator.py
+++ b/yolog/yolog_generator.py
@@ -1,6 +1,6 @@
 from ConfigParser import SafeConfigParser
 import os
-import sys
+
 
 RESET  = "$(tput sgr0)"
 BACKSPACE = "%x08"


### PR DESCRIPTION
This PR introduces better customization of colors of components on the go.
#### Setup / Installation :
- During installation, a new file named **config.ini** is made under **.yolog** directory in **_HOME_** (`~/.yolog/config.ini`).
- All the default colors are stored in this file.
- If user has used `sudo` privileges while installation, it is advisable to change owner of this file from `root` from current user using command `chown`.

---
#### During execution of `yolog`:
- While executing yolog, all the colors are parsed from the config file and set accordingly.

---
#### Changing colors:
- The colors of any component can be easily changed now. The command for it goes as:

```
yolog config [attribute] [color]
```
- Attributes: author, date, description, hash, refs
- Color: _RED, YELLOW, GREEN, BLUE, BLACK, WHITE, PURPLE, CYAN_

This color attribute is edited and stored back in the INI file.
