### PR TITLE
fixed #8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@ import os
 import shutil
 import sys
 from setuptools import setup
-from ConfigParser import SafeConfigParser
+try:
+    from ConfigParser import SafeConfigParser
+except ImportError:
+    from configparser import SafeConfigParser
 
 config_dirpath = os.path.expandvars(os.path.expanduser("~/.yolog"))
 

--- a/yolog/config_handler.py
+++ b/yolog/config_handler.py
@@ -1,6 +1,10 @@
 from __future__ import print_function
-from ConfigParser import SafeConfigParser
 import os
+try:
+    from ConfigParser import SafeConfigParser
+except ImportError:
+    from configparser import SafeConfigParser
+
 
 
 class ConfigHandler(object):

--- a/yolog/yolog_generator.py
+++ b/yolog/yolog_generator.py
@@ -1,5 +1,9 @@
-from ConfigParser import SafeConfigParser
 import os
+try:
+    from ConfigParser import SafeConfigParser
+except ImportError:
+    from configparser import SafeConfigParser
+
 
 
 RESET  = "$(tput sgr0)"


### PR DESCRIPTION
Add try-except block for import of ConfigParser.
This solves issue of compatibility between Python 2 and 3.
